### PR TITLE
update Dockerfile after migrating to public node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN mv ./.npmrc ./.npmrc.dev
-RUN mv ./.npmrc.prod ./.npmrc
 RUN npm run clean-build
 RUN rm -rf ./src
-# Uncomment once core-plugins repo exists and is installable
-# RUN npm prune --production
+RUN npm prune --production
 
 
 EXPOSE 8000


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix


## Summary of Bug Fix
npmrc's were removed since we're now using public node modules
Update Dockerfile to reflect this and prune dependencies to lessen image size