### PR TITLE
Add ARCH as build-arg to docker build

### DIFF
--- a/buildspecs/dev-build.sh
+++ b/buildspecs/dev-build.sh
@@ -14,7 +14,7 @@ docker login -u AWS -p $(aws ecr get-login-password --region $region) $ecrEndpoi
 docker build \
   --progress plain \
   --build-arg NPM_TOKEN=${NPM_TOKEN} \
-  --build-arg ARCH=${ARCH}
+  --build-arg ARCH=${ARCH} \
   -t "$appName:$commitSha-${ARCH}" \
   -t "$appName:$version-${ARCH}" \
   -t "$appName:latest-${ARCH}" . \


### PR DESCRIPTION
This PR passes the ARCH build arg to the docker build so that it can internally use the correct platform