### PR TITLE
pass params to child widgets, always evaluate default values

### DIFF
--- a/src/clients/widget-client.ts
+++ b/src/clients/widget-client.ts
@@ -5,7 +5,7 @@ import upperFirst from 'lodash.upperfirst';
 import camelCase from 'lodash.camelcase';
 import get from 'lodash.get';
 import { Widget } from '@tinystacks/ops-model';
-import { BaseProvider, BaseWidget } from '@tinystacks/ops-core';
+import { BaseWidget } from '@tinystacks/ops-core';
 import {
   GetWidgetArguments,
   HydrateWidgetReferencesArguments,
@@ -154,7 +154,7 @@ const WidgetClient = {
         }
         return property;
       } else if ('$ref' in property) {
-        return await this.resolveWidgetPropertyReference(property, widgets, providers, referencedWidgets);
+        return await this.resolveWidgetPropertyReference({ property, widgets, providers, referencedWidgets, parameters });
       } else {
         for (const p in property) {
           property[p] = await this.resolveWidgetPropertyReferences({
@@ -187,17 +187,22 @@ const WidgetClient = {
 
     return property;
   },
-  async resolveWidgetPropertyReference (
-    property: any, widgets: Record<string, BaseWidget>, providers: Record<string, BaseProvider>,
-    referencedWidgets: Record<string, Widget>
-  ) {
+  async resolveWidgetPropertyReference (args: ResolveWidgetPropertyReferencesArguments) {
+    const {
+      property,
+      widgets,
+      providers,
+      referencedWidgets,
+      parameters = {}
+    } = args;
     const widgetId = property.$ref.split('/')[3];
     const refWidget = widgets[widgetId];
     if (!referencedWidgets[refWidget.id]) {
       referencedWidgets[refWidget.id] = await this.hydrateWidgetReferences({
         widget: refWidget,
         widgets,
-        providers
+        providers,
+        parameters
       });
     }
     const fullRefWidget = referencedWidgets[refWidget.id];

--- a/src/utils/parsing-utils.ts
+++ b/src/utils/parsing-utils.ts
@@ -61,47 +61,45 @@ function castToType (value: any, type: Parameter.type | string) {
 }
 
 function castParametersToDeclaredTypes (widgetId: string, parameters: Json = {}, dashboards: Record<string, DashboardParser> = {}, dashboardId?: string): Json {
-  if (Object.keys(parameters).length > 0) {
-    const parameterKeys = Object.keys(parameters).sort();
-    const dashboardContext = dashboardId ?
-      dashboards[dashboardId] :
-      Object.values(dashboards).find((dashboard) => {
-        const parameterNames = dashboard.parameters.map(param => param.name).sort();
-        return (
-          dashboard.widgetIds.includes(widgetId) &&
-          difference(parameterKeys, parameterNames).length === 0
-        );
-      });
-
-    if (dashboardContext) {
-      const castParameters = Object.fromEntries(
-        Object.entries(parameters).map(([key, value]) => {
-          const parameterDefinition = dashboardContext.parameters.find(param => param.name === key);
-          const parameterType = parameterDefinition?.type || 'string';
-          const castValue = castToType(value, parameterType);
-          return [key, castValue];
-        })
+  const parameterKeys = Object.keys(parameters).sort();
+  const dashboardContext = dashboardId ?
+    dashboards[dashboardId] :
+    Object.values(dashboards).find((dashboard) => {
+      const parameterNames = dashboard.parameters.map(param => param.name).sort();
+      return (
+        dashboard.widgetIds.includes(widgetId) &&
+        difference(parameterKeys, parameterNames).length === 0
       );
-      const existingParams = Object.keys(castParameters);
-      const defaultParameters = dashboardContext.parameters.filter(param => !existingParams.includes(param.name))
-        .reduce((acc: Json, param: Parameter): Json => {
-          const {
-            name,
-            type,
-            default: defaultValue
-          } = param;
+    });
 
-          if (defaultValue) {
-            acc[name] = type ? castToType(defaultValue, type) : defaultValue;
-          }
+  if (dashboardContext) {
+    const castParameters = Object.fromEntries(
+      Object.entries(parameters).map(([key, value]) => {
+        const parameterDefinition = dashboardContext.parameters.find(param => param.name === key);
+        const parameterType = parameterDefinition?.type || 'string';
+        const castValue = castToType(value, parameterType);
+        return [key, castValue];
+      })
+    );
+    const existingParams = Object.keys(castParameters);
+    const defaultParameters = dashboardContext.parameters.filter(param => !existingParams.includes(param.name))
+      .reduce((acc: Json, param: Parameter): Json => {
+        const {
+          name,
+          type,
+          default: defaultValue
+        } = param;
 
-          return acc;
-        }, {});
-      return {
-        ...defaultParameters,
-        ...castParameters
-      };
-    }
+        if (defaultValue) {
+          acc[name] = type ? castToType(defaultValue, type) : defaultValue;
+        }
+
+        return acc;
+      }, {});
+    return {
+      ...defaultParameters,
+      ...castParameters
+    };
   }
   return parameters;
 }


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix


## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
1. Params were only de-reffed when on the widget being requested breaking data-sharing between widgets that use parameters.
2. Default parameters were only extracted from the dashboard definition when query params were passed.

### New Behaviour
_Description of the bug fix and it's impact_
1. Pass parameters down the chain to allow a widget to get data from a child widget that uses a param.
2. Always extract default parameters