### PR TITLE
Safe providers

### DIFF
--- a/src/clients/console-client/local.ts
+++ b/src/clients/console-client/local.ts
@@ -38,6 +38,8 @@ class LocalConsoleClient implements IConsoleClient {
   }
   async saveConsole (consoleName: string, console: ConsoleParser): Promise<ConsoleParser> {
     console.name = consoleName;
+    const previousConsole = await this.getConsole(consoleName);
+    console.providers = previousConsole.providers;
     const yamlConsole = await console.toYaml();
     const consoleYml = yaml.dump({ Console: yamlConsole });
     const configPath = process.env.CONFIG_PATH;

--- a/src/clients/console-client/s3.ts
+++ b/src/clients/console-client/s3.ts
@@ -197,6 +197,8 @@ class S3ConsoleClient implements IConsoleClient {
 
   async saveConsole (consoleName: string, console: ConsoleParser): Promise<ConsoleParser> {
     console.name = consoleName;
+    const previousConsole = await this.getConsole(consoleName);
+    console.providers = previousConsole.providers;
     const yamlConsole = await console.toYaml();
     const consoleYml = yaml.dump({ Console: yamlConsole });
     const configPath = process.env.CONFIG_PATH;

--- a/test/clients/console-client/local.test.ts
+++ b/test/clients/console-client/local.test.ts
@@ -150,6 +150,7 @@ describe('local console client tests', () => {
   describe('saveConsole', () => {
     it('throws InternalServerError if CONFIG_PATH is not set', async () => {
       const mockConsole = await ConsoleParser.fromJson(mockConsoleJson);
+      jest.spyOn(LocalConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
       let thrownError;
       try {
         await localConsoleClient.saveConsole('mock-console', mockConsole);
@@ -169,7 +170,7 @@ describe('local console client tests', () => {
       process.env.CONFIG_PATH = mockConfigPath;
       mockResolve.mockReturnValueOnce(mockConfigPath);
       mockDump.mockReturnValueOnce(mockConfigYaml);
-      jest.spyOn(LocalConsoleClient.prototype, 'getConsole').mockResolvedValueOnce(mockConsole);
+      jest.spyOn(LocalConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
 
       const result = await localConsoleClient.saveConsole('mock-console', mockConsole);
 
@@ -187,6 +188,7 @@ describe('local console client tests', () => {
     it('logs and re-throws errors', async () => {
       const mockConfigPath = './mock.yml';
       const mockConsole = await ConsoleParser.fromJson(mockConsoleJson);
+      jest.spyOn(LocalConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
       const mockError = new Error();
       process.env.CONFIG_PATH = mockConfigPath;
       mockWriteFileSync.mockImplementationOnce(() => { throw mockError; });

--- a/test/clients/console-client/s3.test.ts
+++ b/test/clients/console-client/s3.test.ts
@@ -250,6 +250,7 @@ describe('local console client tests', () => {
   describe('saveConsole', () => {
     it('throws InternalServerError if CONFIG_PATH is not set', async () => {
       const mockConsole = await ConsoleParser.fromJson(mockConsoleJson);
+      jest.spyOn(S3ConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
       let thrownError;
       try {
         await s3ConsoleClient.saveConsole(mockConsoleName, mockConsole);
@@ -267,7 +268,7 @@ describe('local console client tests', () => {
 
       process.env.CONFIG_PATH = mockConfigPath;
       mockDump.mockReturnValueOnce(mockConfigYaml);
-      jest.spyOn(S3ConsoleClient.prototype, 'getConsole').mockResolvedValueOnce(mockConsole);
+      jest.spyOn(S3ConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
 
       const result = await s3ConsoleClient.saveConsole(mockConsoleName, mockConsole);
 
@@ -298,6 +299,7 @@ describe('local console client tests', () => {
     it('logs and re-throws errors', async () => {
       const mockConfigPath = `s3://${mockConfigBucket}/${mockUser}/${mockConfigFileName}`;
       const mockConsole = await ConsoleParser.fromJson(mockConsoleJson);
+      jest.spyOn(S3ConsoleClient.prototype, 'getConsole').mockResolvedValue(mockConsole);
       const mockError = new Error();
       process.env.CONFIG_PATH = mockConfigPath;
       mockWriteFileSync.mockImplementationOnce(() => { throw mockError; });

--- a/test/utils/parsing-utils.test.ts
+++ b/test/utils/parsing-utils.test.ts
@@ -258,7 +258,7 @@ describe('parsing-utils', () => {
         expect(result).toEqual(true);
       });
       it('logs an error for non-castable value and returns original value', () => {
-        jest.spyOn(global.console, 'error');
+        jest.spyOn(global.console, 'error').mockImplementation(jest.fn());
 
         const result = castToType('abc', Parameter.type.BOOLEAN);
 
@@ -279,7 +279,7 @@ describe('parsing-utils', () => {
         expect(result).toEqual(new Date('2023-04-07'));
       });
       it('logs an error for non-castable value and returns original value', () => {
-        jest.spyOn(global.console, 'error');
+        jest.spyOn(global.console, 'error').mockImplementation(jest.fn());
 
         const result = castToType('abc', Parameter.type.DATE);
 
@@ -300,7 +300,7 @@ describe('parsing-utils', () => {
         expect(result).toEqual(321);
       });
       it('logs an error for non-castable value and returns original value', () => {
-        jest.spyOn(global.console, 'error');
+        jest.spyOn(global.console, 'error').mockImplementation(jest.fn());
 
         const result = castToType('abc', Parameter.type.NUMBER);
 
@@ -310,7 +310,7 @@ describe('parsing-utils', () => {
       });
     });
     it('default', () => {
-      jest.spyOn(global.console, 'error');
+      jest.spyOn(global.console, 'error').mockImplementation(jest.fn());
 
       const result = castToType('abc', 'nonsense');
 


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Patch

## Summary of Patch
Overwrites console.providers with the value from the config on save.

## Other details
This is a peer dependency of https://github.com/tinystacks/ops-aws-core-widgets/pull/25

