### PR TITLE
Create/Update Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-api-gateway": "^3.267.0",
         "@aws-sdk/client-s3": "^3.288.0",
         "@aws-sdk/credential-providers": "^3.282.0",
-        "@tinystacks/ops-core": "^0.3.0",
+        "@tinystacks/ops-core": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",
         "body-parser": "^1.20.1",
@@ -4186,8 +4186,8 @@
     },
     "node_modules/@tinystacks/ops-core": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tinystacks/ops-core/-/ops-core-0.3.0.tgz",
-      "integrity": "sha512-eiJt4B+aaTavSOmv9Zul/tx1dUSbBmh1vn9gDBRqy6y8wJdqzO+isaJrVGtmun9HckglvQ7FmsdHdTT2f6p6bw==",
+      "resolved": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
+      "integrity": "sha512-6ViMudgzRMvg46f9CrfkYoBTEt8dtV450WkfUWw0qFCMYe72+tYRxOI18OBbEogfo3qlNxPg6E3PMoMmLVO9MQ==",
       "dependencies": {
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",
@@ -15546,9 +15546,8 @@
       }
     },
     "@tinystacks/ops-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tinystacks/ops-core/-/ops-core-0.3.0.tgz",
-      "integrity": "sha512-eiJt4B+aaTavSOmv9Zul/tx1dUSbBmh1vn9gDBRqy6y8wJdqzO+isaJrVGtmun9HckglvQ7FmsdHdTT2f6p6bw==",
+      "version": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
+      "integrity": "sha512-6ViMudgzRMvg46f9CrfkYoBTEt8dtV450WkfUWw0qFCMYe72+tYRxOI18OBbEogfo3qlNxPg6E3PMoMmLVO9MQ==",
       "requires": {
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-api-gateway": "^3.267.0",
         "@aws-sdk/client-s3": "^3.288.0",
         "@aws-sdk/credential-providers": "^3.282.0",
-        "@tinystacks/ops-core": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
+        "@tinystacks/ops-core": "^0.3.2",
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",
         "body-parser": "^1.20.1",
@@ -4185,9 +4185,9 @@
       }
     },
     "node_modules/@tinystacks/ops-core": {
-      "version": "0.3.0",
-      "resolved": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
-      "integrity": "sha512-6ViMudgzRMvg46f9CrfkYoBTEt8dtV450WkfUWw0qFCMYe72+tYRxOI18OBbEogfo3qlNxPg6E3PMoMmLVO9MQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@tinystacks/ops-core/-/ops-core-0.3.2.tgz",
+      "integrity": "sha512-YTN2KHgtQgf3srcn8yH87kmvRqr/W5DSEWsi6fKFy+IoSd7/Mpv7QEijwadgNvlqEPbE9gixqERxsDatKcSCgA==",
       "dependencies": {
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",
@@ -15546,8 +15546,9 @@
       }
     },
     "@tinystacks/ops-core": {
-      "version": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
-      "integrity": "sha512-6ViMudgzRMvg46f9CrfkYoBTEt8dtV450WkfUWw0qFCMYe72+tYRxOI18OBbEogfo3qlNxPg6E3PMoMmLVO9MQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@tinystacks/ops-core/-/ops-core-0.3.2.tgz",
+      "integrity": "sha512-YTN2KHgtQgf3srcn8yH87kmvRqr/W5DSEWsi6fKFy+IoSd7/Mpv7QEijwadgNvlqEPbE9gixqERxsDatKcSCgA==",
       "requires": {
         "@tinystacks/ops-model": "^0.4.0",
         "@types/react": "^18.0.28",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@aws-sdk/client-api-gateway": "^3.267.0",
     "@aws-sdk/client-s3": "^3.288.0",
     "@aws-sdk/credential-providers": "^3.282.0",
-    "@tinystacks/ops-core": "^0.3.0",
+    "@tinystacks/ops-core": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
     "@tinystacks/ops-model": "^0.4.0",
     "@types/react": "^18.0.28",
     "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@aws-sdk/client-api-gateway": "^3.267.0",
     "@aws-sdk/client-s3": "^3.288.0",
     "@aws-sdk/credential-providers": "^3.282.0",
-    "@tinystacks/ops-core": "file:../ops-core/tinystacks-ops-core-0.3.0.tgz",
+    "@tinystacks/ops-core": "^0.3.2",
     "@tinystacks/ops-model": "^0.4.0",
     "@types/react": "^18.0.28",
     "body-parser": "^1.20.1",

--- a/src/controllers/dashboard-controller.ts
+++ b/src/controllers/dashboard-controller.ts
@@ -16,7 +16,6 @@ const DashboardController = {
   },
   async putDashboard (consoleName: string, dashboardId: string, updateDashboardBody: DashboardType): Promise<DashboardType> {
     const dashboard: DashboardParser = DashboardParser.fromJson(updateDashboardBody);
-    dashboard.route = dashboardId;
     return (await DashboardClient.updateDashboard(consoleName, dashboardId, dashboard)).toJson();
   },
   async deleteDashboard (consoleName: string, dashboardId: string): Promise<DashboardType> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { BaseProvider, BaseWidget } from '@tinystacks/ops-core';
+import { BaseProvider, BaseWidget, DashboardParser } from '@tinystacks/ops-core';
 import { Constant, Widget } from '@tinystacks/ops-model';
 
 type Json = {
@@ -20,6 +20,8 @@ type HydrateWidgetReferencesArguments = {
   overrides?: Json;
   parameters?: Json;
   constants?: Record<string, Constant>;
+  dashboards: Record<string, DashboardParser>;
+  dashboardId?: string;
 };
 
 type ResolveWidgetPropertyReferencesArguments = {
@@ -29,6 +31,8 @@ type ResolveWidgetPropertyReferencesArguments = {
   referencedWidgets: Record<string, Widget>;
   parameters?: Json;
   constants?: Record<string, Constant>;
+  dashboards: Record<string, DashboardParser>;
+  dashboardId?: string;
 }
 
 export {

--- a/src/utils/parsing-utils.ts
+++ b/src/utils/parsing-utils.ts
@@ -66,10 +66,17 @@ function castParametersToDeclaredTypes (widgetId: string, parameters: Json = {},
     dashboards[dashboardId] :
     Object.values(dashboards).find((dashboard) => {
       const parameterNames = dashboard.parameters.map(param => param.name).sort();
-      return (
-        dashboard.widgetIds.includes(widgetId) &&
-        difference(parameterKeys, parameterNames).length === 0
+      const dashboardUsesWidget = dashboard.widgetIds.includes(widgetId);
+      const dashboardDefinesAllPassesParams = difference(parameterKeys, parameterNames).length === 0;
+      const noParamsWerePassed = parameterKeys.length === 0;
+      const dashboardPredicateResult = (
+        dashboardUsesWidget &&
+        (
+          dashboardDefinesAllPassesParams ||
+          noParamsWerePassed
+        )
       );
+      return dashboardPredicateResult;
     });
 
   if (dashboardContext) {

--- a/test/controllers/dashboard-controller.test.ts
+++ b/test/controllers/dashboard-controller.test.ts
@@ -46,15 +46,12 @@ describe('dashboard controller tests', () => {
       widgetIds: [],
       parameters: []
     };
-    await DashboardController.putDashboard('mock-console', '/mock-dashboard-2', requestBody);
+    await DashboardController.putDashboard('mock-console', 'mock-dashboard', requestBody);
     expect(mockUpdateDashboard).toBeCalled();
     expect(mockUpdateDashboard).toBeCalledWith(
       'mock-console',
-      '/mock-dashboard-2',
-      {
-        ...requestBody,
-        route: '/mock-dashboard-2'
-      }
+      'mock-dashboard',
+      requestBody
     );
   });
   it('deleteDashboard', async () => {


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [ ] Bug Fix
 - [x] Patch

## Link to Notion Task or Github Issue
[Create/Update Dashboard](https://www.notion.so/tinystacks/Goals-07ccd37a0c9d4bd5bad6fc3dbbe13995)

## Summary of Patch
1. Update ops-core for better error handling.
2. Don't overwrite dashboard route with id
3. Hydrate params for non-direct dashboard children
        - Previously, when updating a widget that is not a direct child of a dashboard, any params or references to params would not be hydrated causing an error.
        - Now, we hydrate params when the passed params are empty (PUT requests) by hydrating defaults for referenced properties.  This fixes the issue for widgets that reference a property of another widget that is a dashboard level parameter.  However, if a non-direct child widget references a dashboard parameter directly, we could still encounter the same error.  To truly fix this error, we would have to pass the dashboard id that is in context when editing a widget or dig one out server-side (top-down recursive find from the dashboard widgetIds until we discover the widget in question).

## Dependencies
https://github.com/tinystacks/ops-core/pull/38